### PR TITLE
Update startvm

### DIFF
--- a/bin/startvm
+++ b/bin/startvm
@@ -134,8 +134,8 @@ configureNetworks
 iptables -A POSTROUTING -t mangle -p udp --dport bootpc -j CHECKSUM --checksum-fill
 
 # Build DNS options from container /etc/resolv.conf
-nameservers=($(grep nameserver /etc/resolv.conf | sed 's/nameserver //'))
-searchdomains=$(grep search /etc/resolv.conf | sed 's/search //' | sed 's/ /,/g')
+nameservers=($(grep '^nameserver' /etc/resolv.conf | sed 's/nameserver //'))
+searchdomains=$(grep '^search' /etc/resolv.conf | sed 's/search //' | sed 's/ /,/g')
 domainname=$(echo $searchdomains | awk -F"," '{print $1}')
 
 for nameserver in "${nameservers[@]}"; do


### PR DESCRIPTION
fix for grep file.
now it only grep lines with beginning 'search' and 'nameserver'